### PR TITLE
Close the color when printing next actions

### DIFF
--- a/na.sh
+++ b/na.sh
@@ -21,6 +21,7 @@ function na() {
       echo -en $GREEN
       grep -h "$NA_NEXT_TAG" *.taskpaper | grep -v "$NA_DONE_TAG" | awk '{gsub(/(^[ \t]+| '"$NA_NEXT_TAG"')/, "")};1'
       echo "`pwd`" >> ~/.tdlist
+      echo -en "\033[00m"
       sort -u ~/.tdlist -o ~/.tdlist
     fi
     return


### PR DESCRIPTION
This left the first part of my prompt the color from the next action because I don't open my $PS1 with a color block.
