### PR TITLE
FIX make autolist work if PROMPT_COMMAND is blank

### DIFF
--- a/na.sh
+++ b/na.sh
@@ -302,5 +302,9 @@ WEEDTIME
 }
 
 if [[ $NA_AUTO_LIST_FOR_DIR -eq 1 ]]; then
-  echo $PROMPT_COMMAND | grep -v -q "na --prompt" && PROMPT_COMMAND="$PROMPT_COMMAND;"'eval "na --prompt"'
+  if [[ -z "$PROMPT_COMMAND" ]]; then
+    PROMPT_COMMAND="eval 'na --prompt'"
+  else
+    echo $PROMPT_COMMAND | grep -v -q "na --prompt" && PROMPT_COMMAND="$PROMPT_COMMAND;"'eval "na --prompt"'
+  fi
 fi


### PR DESCRIPTION
Hi Brett,

I thought `na` looked neat and wanted to try it out. I realize that you're not actively working on `na`, but here is a small bugfix that makes na work for users who don't have PROMPT_COMMAND set. These users would otherwise encounter this error out-of-the box:

```
  -bash: PROMPT_COMMAND: line 0: syntax error near unexpected token `;'
  -bash: PROMPT_COMMAND: line 0: `;eval "na --prompt"'
```

Thanks for helping me to rethink my task-tracking in the terminal!
