### PR TITLE
Fix issues with helptext and 'find'

### DIFF
--- a/na.sh
+++ b/na.sh
@@ -28,7 +28,7 @@ function na() {
   local DEFAULT="\033[0;39m"
   local CYAN="\033[0;36m"
   local YELLOW="\033[0;33m"
-  IFS='' read -r -d '' helpstring <<'ENDHELPSTRING'
+  IFS='' read -r -d '' helpstring <<ENDHELPSTRING
 na [-r] [-t tag [-v value]] [query [additional identifiers]]
 na -a [-n] [-t tag] 'todo text'
 
@@ -69,7 +69,7 @@ ENDHELPSTRING
           priority=0
         fi
         ;;
-      h) echo $helpstring >&2; return;;
+      h) echo "${helpstring}" >&2; return;;
       t)
         if [[ $2 != '' && $2 =~ ^[^\-] ]]; then
           shift; altTag="@${1#@}"
@@ -125,12 +125,13 @@ ENDHELPSTRING
       echo "`pwd`" >> ~/.tdlist
       sort -u ~/.tdlist -o ~/.tdlist
     fi
+    echo -en $DEFAULT
     return
   fi
 
   if [[ $recurse -eq 1 && ${#fnd} -eq 0 ]]; then # if the only argument is -r
     # echo -en $GREEN
-    dirlist=$(find -maxdepth $NA_MAX_DEPTH . -name "*.$NA_TODO_EXT" -exec grep -H "$taskTag" {} \; | grep -v "$NA_DONE_TAG")
+    dirlist=$(find . -maxdepth $NA_MAX_DEPTH -name "*.$NA_TODO_EXT" -exec grep -H "$taskTag" {} \; | grep -v "$NA_DONE_TAG")
     _na_fix_output "$dirlist"
   elif [[ $add -eq 1 ]]; then # if the argument is -a
     [[ $fnd == '' ]] && read -p "Task: " fnd # No text given for the task, read from STDIN
@@ -249,7 +250,7 @@ SCRIPTTIME
     fi
     if [[ $recurse -eq 1 ]]; then
       echo -e "$DKGRAY[$target+]:"
-      dirlist=$(find -maxdepth $NA_MAX_DEPTH "$target" -name "*.$NA_TODO_EXT" -exec grep -EH "(^\t*-|: *@.*$)" {} \; | grep -v "$NA_DONE_TAG" | grep -H "$taskTag")
+      dirlist=$(find  "$target" -maxdepth $NA_MAX_DEPTH -name "*.$NA_TODO_EXT" -exec grep -EH "(^\t*-|: *@.*$)" {} \; | grep -v "$NA_DONE_TAG" | grep -H "$taskTag")
       _na_fix_output "$dirlist"
     else
       CHKFILES=$(ls -C1 $target/*.$NA_TODO_EXT 2> /dev/null | wc -l)


### PR DESCRIPTION
I encountered a few issues on my Mac which I fixed:

- Helptext was not structured, all on a single line of text
- 'find' complained invalid maxdepth
- After calling 'na' the terminal was left in green text color


